### PR TITLE
Add Pluggable Translation Service to `lisan` Package for Dynamic Translations

### DIFF
--- a/lisan/admin.py
+++ b/lisan/admin.py
@@ -10,6 +10,8 @@ class LisanAdminMixin(admin.ModelAdmin):
     localized content within the Django admin interface.
     """
 
+    lisan_display_format = "{field_name} ({language_code})"
+
     def __init__(self, *args, **kwargs):
         """
         Initialize the LisanAdminMixin.
@@ -31,12 +33,12 @@ class LisanAdminMixin(admin.ModelAdmin):
         for field_name in self.model.lisan_fields:
             method_name = f'get_lisan_{field_name}'
             setattr(self, method_name, self._create_lisan_getter(field_name))
-            
-            # Set a short description for the admin list display
-            short_description = f'{field_name.capitalize()} (EN)'
+
+            short_description = self.lisan_display_format.format(
+                field_name=field_name.capitalize(), language_code='EN'
+            )
             getattr(self, method_name).short_description = short_description
 
-            # Add the generated method to the list_display
             if 'list_display' in self.__dict__:
                 self.list_display += (method_name,)
             else:

--- a/lisan/middleware.py
+++ b/lisan/middleware.py
@@ -25,8 +25,11 @@ class LanguageMiddleware(MiddlewareMixin):
         Args:
             request: The HTTP request object.
         """
-        language_code = request.headers.get(
-            'Accept-Language',
-            getattr(settings, 'LISAN_DEFAULT_LANGUAGE', 'en')
+        language_code = (
+            request.GET.get('lang') or
+            getattr(request.user, 'profile.language_preference', None) or
+            request.COOKIES.get('language') or
+            request.headers.get('Accept-Language') or
+            'en'
         )
         request.language_code = language_code

--- a/lisan/mixins.py
+++ b/lisan/mixins.py
@@ -1,6 +1,8 @@
+from django.conf import settings
 from django.db import models, IntegrityError, transaction
 from django.core.exceptions import ObjectDoesNotExist, FieldDoesNotExist
 from .metaclasses import LisanModelMeta
+from .utils import get_translation_service
 
 
 class LisanModelMixin(models.Model, metaclass=LisanModelMeta):
@@ -102,45 +104,103 @@ class LisanModelMixin(models.Model, metaclass=LisanModelMeta):
         except Exception as e:
             raise e
 
+    def set_bulk_lisans(self, translations):
+        """
+        Set or update translations for multiple languages in bulk.
+
+        Args:
+            translations (dict): A dictionary where each key is a language
+                                code (str) and the corresponding value is a
+                                dictionary of fields (dict) to be set or
+                                updated for that language.
+                                
+                                Example:
+                                {
+                                    'en': {
+                                        'field1': 'value1',
+                                        'field2': 'value2'
+                                    },
+                                    'fr': {
+                                        'field1': 'valeur1',
+                                        'field2': 'valeur2'
+                                    }
+                                }
+
+        Behavior:
+            This method updates the Lisan (translation) model for each
+            specified language in bulk. For each language code in the
+            `translations` dictionary, the corresponding fields
+            and their values are passed to the `set_lisan` method for
+            that language.
+
+        Transaction:
+            The operation is wrapped in a database transaction to ensure
+            that either all translations are successfully updated or none
+            of them are (atomic operation).
+
+        Raises:
+            Exception: Any exceptions encountered during the transaction
+            will cause the entire operation to roll back, ensuring data
+            consistency.
+        """
+        with transaction.atomic():
+            for language_code, fields in translations.items():
+                self.set_lisan(language_code, **fields)
+
     def get_lisan_field(
-        self, field_name, language_code=None, fallback_to_default=True
-    ):
+            self, field_name,
+            language_code=None,
+            fallback_languages=None,
+            auto_translate=False):
         """
         Retrieve a specific field's value from the Lisan (translation) model.
 
         Args:
             field_name (str): The name of the field to retrieve.
-            language_code (str): The language code to retrieve the field for.
-                                 Defaults to the current language.
-            fallback_to_default (bool): Whether to fallback to the default
-                                        language ('en') if the field is not
-                                        found in the specified language.
-                                        Defaults to True.
+            language_code (str, optional): The language code to retrieve the
+                                           field for. Defaults to the current
+                                           language if not provided.
+            fallback_languages (list, optional): A list of fallback language
+                                                 codes to try if the field is
+                                                 not found in the specified
+                                                 language. Defaults to a list
+                                                 of fallback languages set in
+                                                 the configuration or ['en'].
+            auto_translate (bool, optional): Whether to automatically translate
+                                             the field value if it is not found
+                                             in the specified language.
+                                             Defaults to False.
 
         Returns:
-            Any: The value of the specified field.
+            Any: The value of the specified field from the Lisan translation
+                 model. If the field is not found in any of the provided
+                 languages, it returns the default field value from the main
+                 model. If `auto_translate` is True, it attempts to translate
+                 the value to the requested language if not found.
 
         Raises:
             AttributeError: If the field does not exist in either the model or
                             its translations.
         """
         language_code = language_code or self._current_language
-        try:
-            lisan = self.get_lisan(language_code)
+        fallback_languages = fallback_languages or getattr(
+            settings, 'LISAN_FALLBACK_LANGUAGES', ['en']
+        )
+        # Try to get the field from available translations
+        for lang in [language_code] + fallback_languages:
+            lisan = self.get_lisan(lang)
             if lisan and hasattr(lisan, field_name):
                 return getattr(lisan, field_name)
-            elif fallback_to_default:
-                default_lisan = self.get_lisan('en')
-                if default_lisan and hasattr(default_lisan, field_name):
-                    return getattr(default_lisan, field_name)
-            return getattr(self, field_name)
-        except AttributeError:
-            raise AttributeError(
-                f"Field '{field_name}' does not exist in either the model or "
-                "its translations."
-            )
-        except Exception as e:
-            raise e
+        
+        # If auto-translation is enabled, use the translation service
+        if auto_translate:
+            original_text = getattr(self, field_name)
+            translation_service = get_translation_service()
+            return translation_service.translate(
+                original_text, target_language=language_code)
+
+        # Fallback to default field
+        return getattr(self, field_name)
 
     def set_current_language(self, language_code):
         """
@@ -156,3 +216,31 @@ class LisanModelMixin(models.Model, metaclass=LisanModelMeta):
         if not language_code:
             raise ValueError("Language code must be provided")
         self._current_language = language_code
+
+    def is_field_translatable(self, field_name):
+        """
+        Determine if the given field is translatable for this instance.
+
+        Args:
+            field_name (str): The name of the field to check for
+            translatability.
+
+        Returns:
+            bool: True if the field is translatable (i.e., exists in
+            `lisan_fields`), False otherwise.
+
+        Behavior:
+            This method checks if the specified field is considered
+            translatable by verifying its presence in the `lisan_fields`
+            attribute. The `lisan_fields` attribute is expected to
+            contain a list or set of field names that are marked for
+            translation.
+
+        Example:
+            >>> instance.is_field_translatable('title')
+            True
+
+            >>> instance.is_field_translatable('non_translatable_field')
+            False
+        """
+        return field_name in self.lisan_fields

--- a/lisan/translation_services.py
+++ b/lisan/translation_services.py
@@ -1,0 +1,29 @@
+class BaseTranslationService:
+    """
+    A base class for translation services.
+
+    This class defines the interface that all translation service subclasses
+    must implement. Specifically, any subclass must provide its own
+    implementation of the `translate` method, which will handle translating 
+    text to the target language.
+    """
+
+    def translate(self, text, target_language):
+        """
+        Translate the given text to the target language.
+
+        Args:
+            text (str): The text to be translated.
+            target_language (str): The language code of the target language
+                                   for the translation.
+
+        Returns:
+            str: The translated text in the target language.
+
+        Raises:
+            NotImplementedError: If this method is not overridden by a
+            subclass.
+        """
+        raise NotImplementedError(
+            "This method must be overridden by subclasses."
+        )

--- a/lisan/utils.py
+++ b/lisan/utils.py
@@ -1,0 +1,34 @@
+from importlib import import_module
+from django.conf import settings
+
+
+def get_translation_service():
+    """
+    Dynamically import and instantiate the translation service class defined 
+    in the settings.
+
+    This function assumes that the `LISAN_DEFAULT_TRANSLATION_SERVICE` setting
+    is a fully qualified Python path string in the format 'module.ClassName'.
+
+    The module and class name are extracted from this setting, and the class
+    is imported dynamically. The class is then instantiated and returned.
+
+    Returns:
+        object: An instance of the translation service class as defined in
+                the settings.
+
+    Raises:
+        ImportError: If the module cannot be imported.
+        AttributeError: If the class is not found within the module.
+    """
+    # Split the module path and class name from the settings
+    module_path, class_name = settings.LISAN_DEFAULT_TRANSLATION_SERVICE.rsplit('.', 1)
+
+    # Import the module dynamically
+    module = import_module(module_path)
+
+    # Retrieve the class from the imported module
+    service_class = getattr(module, class_name)
+
+    # Instantiate and return the translation service class
+    return service_class()


### PR DESCRIPTION
## Summary

This PR introduces a **pluggable translation service** feature to the `lisan` package, allowing developers to integrate external translation services or custom logic for handling dynamic translations of model fields. The system enables auto-translations using third-party services like Google Translate and provides the flexibility to configure the preferred service through Django settings.

## Key Changes
- **Pluggable Translation Service**: Added a base class (`BaseTranslationService`) that allows easy integration with any translation API. Translation services can be dynamically loaded via Django settings (`LISAN_DEFAULT_TRANSLATION_SERVICE`).
- **Auto-Translation**: Updated the `LisanModelMixin` and `LisanSerializerMixin` to optionally auto-translate fields when translations are unavailable.
- **Middleware Enhancement**: Improved the `LanguageMiddleware` to allow multiple ways to set the language (query parameters, cookies, user preferences).
- **Bulk Operations Support**: Introduced a `set_bulk_lisans` method to support bulk creation and updating of translations.
- **Flexible Field Types**: Enhanced support for various Django field types (e.g., `TextField`, `JSONField`) in translation models.

## How to Configure
To enable automatic translations using Google Translate, update your `settings.py` as follows:

```python
LISAN_DEFAULT_TRANSLATION_SERVICE = 'yourapp.google_translate_service.GoogleTranslateService'
```

For fallback language configuration:
```python
LISAN_FALLBACK_LANGUAGES = ['fr', 'es', 'en']
```

## How to Test
1. Make a request to any model with translatable fields and include the `lang` query parameter (e.g., `?lang=es`).
2. If translations are unavailable in the requested language, the system will automatically translate the content using Google Translate.
3. You can switch the translation service by updating the `LISAN_DEFAULT_TRANSLATION_SERVICE` in the settings.