### PR TITLE
optimize: use prefetch cache in get_lisan to reduce redundant DB queries

### DIFF
--- a/lisan/mixins.py
+++ b/lisan/mixins.py
@@ -32,6 +32,15 @@ class LisanModelMixin(models.Model, metaclass=LisanModelMeta):
                            or None if not found.
         """
         language_code = language_code or self._current_language
+        related_name = f"{self._meta.model_name}_lisans"
+
+        if hasattr(self, "_prefetched_objects_cache") and \
+                related_name in self._prefetched_objects_cache:
+            prefetched = self._prefetched_objects_cache.get(related_name) or []
+            for lisan in prefetched:
+                if lisan.language_code == language_code:
+                    return lisan
+            return None
         try:
             filter_kwargs = {
                     "language_code": language_code,


### PR DESCRIPTION
- Updated get_lisan() to check prefetch cache before querying the DB
- Avoids repeated DB hits for each translation lookup
- Added logic to extract translation from `_prefetched_objects_cache`
- Maintains existing fallback behavior if not prefetched